### PR TITLE
refacto: stop using deprecated github action set-output command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -93,10 +93,6 @@ runs:
           </details>
         " "${title:-No changes. Infrastructure is up-to-date.}" "$(git rev-parse --short $GITHUB_SHA)" "$tf_plan" "$(git rev-parse --short $GITHUB_SHA)" "$drift")
 
-        message="${message//'%'/'%25'}"
-        message="${message//$'\n'/'%0A'}"
-        message="${message//$'\r'/'%0D'}"
-
         echo "👨‍💻 display plan"
         echo -e "$tf_plan"
         echo "" 

--- a/action.yaml
+++ b/action.yaml
@@ -103,4 +103,4 @@ runs:
         echo "👨‍💻 display drift"
         echo -e "$drift"
         echo ""
-        echo ::set-output name=plan-details::"$message"
+        echo "plan-details=$message" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -103,4 +103,6 @@ runs:
         echo "👨‍💻 display drift"
         echo -e "$drift"
         echo ""
-        echo "plan-details=$message" >> $GITHUB_OUTPUT
+        echo 'plan-details<<EOF' >> $GITHUB_OUTPUT
+        echo "$message" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Related to https://github.com/gogaille/guest-journey/issues/7514

[See this post :eyes: ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Examples

A workflow using save-state or set-output like the following

```yaml
- name: Save state
  run: echo "::save-state name={name}::{value}"

- name: Set output
  run: echo "::set-output name={name}::{value}"
```

should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files:

```yaml
- name: Save state
  run: echo "{name}={value}" >> $GITHUB_STATE

- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT

```